### PR TITLE
Feature/change credit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.15.0] - 2022-02-17
+### Changed
+- Correcting form of permition to add credit in gift card
+- Correct tests
+
 ## [0.14.0] - 2022-02-08
+### Changed
+- Change form of consulting ACCT API
 
 ## [0.13.0] - 2022-02-08
+### Changed
+-  Creating new functions to
+  - Get the total value of gift card
+  - Get the total value of credit in lists
+  - Get the value that has already been added to the gift card from the total value of the lists
+
 
 ## [0.12.0] - 2022-01-27
 ### Changed

--- a/node/__mocks__/contexts.ts
+++ b/node/__mocks__/contexts.ts
@@ -354,3 +354,34 @@ export const ctxMasterdataWithoutValues = {
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjEyMzQifQ.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwiYWNjb3VudCI6InRlc3QiLCJhdWRpZW5jZSI6ImFkbWluIiwic2VzcyI6InNlc3MiLCJleHAiOiJleHAiLCJ1c2VySWQiOiJ1c2VySWQiLCJpYXQiOjEsImlzcyI6ImlzcyIsImp0aSI6Imp0aSJ9.nnqmVfGsobK5hfdtAu10a0NU36-kFQ0f2LmN4R9rs8Q',
   },
 } as unknown as Context
+
+export const ctxCredit = {
+  clients: {
+    giftCard: {},
+    listGraphql: {
+      checkDataValueList: jest
+        .fn()
+        .mockResolvedValue({ name: 'name', valuePurchased: 5 }),
+    },
+    giftCardList: {
+      searchRaw: jest.fn().mockResolvedValue(searchValues),
+    },
+    vtexid: {
+      getAuthenticatedUser: jest.fn().mockResolvedValue({
+        sub: 'test@test.com',
+        account: 'test',
+        audience: 'admin',
+        sess: 'sess',
+        exp: 'exp',
+        userId: 'userId',
+        iat: 1,
+        iss: 'iss',
+        jti: 'jti',
+      }),
+    },
+  },
+  vtex: {
+    storeUserAuthToken:
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjEyMzQifQ.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwiYWNjb3VudCI6InRlc3QiLCJhdWRpZW5jZSI6ImFkbWluIiwic2VzcyI6InNlc3MiLCJleHAiOiJleHAiLCJ1c2VySWQiOiJ1c2VySWQiLCJpYXQiOjEsImlzcyI6ImlzcyIsImp0aSI6Imp0aSJ9.nnqmVfGsobK5hfdtAu10a0NU36-kFQ0f2LmN4R9rs8Q',
+  },
+} as unknown as Context

--- a/node/__tests__/clients/listGraphql.spec.ts
+++ b/node/__tests__/clients/listGraphql.spec.ts
@@ -13,11 +13,10 @@ describe('List Graphql Client', () => {
   const ListGraphqlClient = new ListGraphql(MOCKED_CONTEXT, MOCKED_OPTIONS)
 
   it('should test if function checkDataValueList work right and have a valid return', async () => {
-    // @ts-ignore
-    const get = jest.spyOn(ListGraphqlClient.http, 'get').mockResolvedValue([
-      { ownerName: 'name', valuePurchased: 1 },
-      { ownerName: 'name', valuePurchased: 2 },
-    ])
+    const get = jest
+      // @ts-ignore
+      .spyOn(ListGraphqlClient.http, 'get')
+      .mockResolvedValue({ name: 'name', valuePurchased: 3 })
 
     const returnValue = await ListGraphqlClient.checkDataValueList(
       'email@email.com.br'
@@ -29,7 +28,7 @@ describe('List Graphql Client', () => {
     })
 
     return expect(get).toHaveBeenCalledWith(
-      `https://${MOCKED_CONTEXT.account}.vtexcommercestable.com.br/api/dataentities/vtex_list_graphql_userLists/search?_schema=1.6.0&_fields=_all&ownerEmail=email@email.com.br`
+      `/_v/getDataList/email@email.com.br`
     )
   })
 })

--- a/node/__tests__/resolver/updateGiftCard.spec.ts
+++ b/node/__tests__/resolver/updateGiftCard.spec.ts
@@ -11,6 +11,7 @@ import {
   ctxMasterdataValueTrue,
   ctxMissingPermissions,
   ctxMissingAuthentication,
+  ctxCredit,
 } from '../../__mocks__/contexts'
 
 describe('Test updateGiftCard', () => {
@@ -62,6 +63,14 @@ describe('Test updateGiftCard', () => {
 
   it('should test if the return value is an error if I send a value > listGraphqlValue.valuePurchased', async () => {
     const returnValue = await updateGiftCard('', { value: 3 }, ctx)
+
+    expect(returnValue).toStrictEqual(
+      `${HTTP_ERROR_MESSAGES.valueBiggerThanCouldBe}2`
+    )
+  })
+
+  it('should test if the return value is an error if I send a value < listGraphqlValue.valuePurchased, but value > credit', async () => {
+    const returnValue = await updateGiftCard('', { value: 3 }, ctxCredit)
 
     expect(returnValue).toStrictEqual(
       `${HTTP_ERROR_MESSAGES.valueBiggerThanCouldBe}2`

--- a/node/resolvers/updateGiftCard.ts
+++ b/node/resolvers/updateGiftCard.ts
@@ -42,7 +42,8 @@ export async function updateGiftCard(
     )
   }
 
-  const masterdataInfo = (await getInfoMasterdata(ctx, email)).data[0]
+  const masterdataInfo = (await getInfoMasterdata(ctx, email))
+    .data[0] as unknown as MasterdataValues
 
   let result = false
 
@@ -84,6 +85,13 @@ export async function updateGiftCard(
     }
 
     return HTTP_ERROR_MESSAGES.failed
+  }
+
+  const credit =
+    listGraphqlValue.valuePurchased - masterdataInfo.quantityAlreadyInGiftCard
+
+  if (value > credit) {
+    return HTTP_ERROR_MESSAGES.valueBiggerThanCouldBe + credit.toString()
   }
 
   result = await giftCard.addCreditInGiftCard(

--- a/node/typings/MasterdataValues.d.ts
+++ b/node/typings/MasterdataValues.d.ts
@@ -1,0 +1,15 @@
+interface HistoryInterface {
+  dateAndTime: string
+  value: number
+  [k: string]: unknown
+}
+
+interface MasterdataValues {
+  giftCardId: string
+  email: string
+  profileId: string
+  redemptionCode: string
+  quantityAlreadyInGiftCard: number
+  history: HistoryInterface[]
+  id: ID
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

The purpose of this PR is change the logic of permition to add credit in gift card. Previously, it was allowed to add a value less than or equal to the amount of credit obtained from the user's gift lists. Now it's only allowed to add the result of the difference between the amount of credit obtained from the user's gift lists and the amount that was previously withdrawn from this list


#### Types of changes

- [ ] Chore (non-breaking change which doesn't change any functionalities)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
